### PR TITLE
Android: Fix console key input bugs

### DIFF
--- a/src/console.c
+++ b/src/console.c
@@ -604,6 +604,11 @@ void CON_ToggleOff(void)
 	con_clipviewtop = -1; // remove console clipping of view
 
 	I_UpdateMouseGrab();
+
+#if (defined(__ANDROID__) && defined(TOUCHINPUTS))
+	if (I_KeyboardOnScreen())
+		I_CloseScreenKeyboard();
+#endif
 }
 
 boolean CON_Ready(void)
@@ -644,6 +649,10 @@ void CON_Ticker(void)
 			con_destlines = 0;
 			CON_ClearHUD();
 			I_UpdateMouseGrab();
+#if (defined(__ANDROID__) && defined(TOUCHINPUTS))
+			if (I_KeyboardOnScreen())
+				I_CloseScreenKeyboard();
+#endif
 		}
 		else
 			CON_ChangeHeight();

--- a/src/sdl/i_video.c
+++ b/src/sdl/i_video.c
@@ -1050,7 +1050,12 @@ void I_GetEvent(void)
 				Impl_HandleTouchEvent(evt.tfinger);
 				break;
 			case SDL_TEXTINPUT:
-				Impl_HandleTextInput(evt.text);
+				// If user pressed the console button, don't type the
+				// character into the console buffer.
+				if (evt.text.text[0] && !evt.text.text[1]
+					&& evt.text.text[0] != gamecontrol[gc_console][0] 
+					&& evt.text.text[0] != gamecontrol[gc_console][1])
+					Impl_HandleTextInput(evt.text);
 				break;
 #endif
 #if 0


### PR DESCRIPTION
Here's a couple fixes:

* Typing the console key would put the key character in the console buffer, when the user intended to toggle the console on or off
* Keys could be typed into the console buffer even when the console was closed. I could trigger this by opening the console via the touch button, then closing it with the keyboard key.