### PR TITLE
Android TouchControlLayout technical fixes

### DIFF
--- a/src/m_menu.c
+++ b/src/m_menu.c
@@ -324,9 +324,9 @@ static void M_AssignJoystick(INT32 choice);
 static void M_ChangeControl(INT32 choice);
 
 #ifdef TOUCHINPUTS
-static void M_LoadTouchControlLayout(void);
-static void M_ClearTouchControlLayout(void);
-static void M_CustomizeTouchControls(void);
+static void M_LoadTouchControlLayout(INT32 choice);
+static void M_ClearTouchControlLayout(INT32 choice);
+static void M_CustomizeTouchControls(INT32 choice);
 #endif
 
 // Video & Sound
@@ -12157,8 +12157,9 @@ static boolean M_TouchPresetActiveMessage(void)
 	return false;
 }
 
-static void M_CustomizeTouchControls(void)
+static void M_CustomizeTouchControls(INT32 choice)
 {
+	(void)choice;
 	if (!M_TouchPresetActiveMessage())
 	{
 		TS_SetupCustomization();
@@ -12166,8 +12167,9 @@ static void M_CustomizeTouchControls(void)
 	}
 }
 
-static void M_LoadTouchControlLayout(void)
+static void M_LoadTouchControlLayout(INT32 choice)
 {
+	(void)choice;
 	if (!M_TouchPresetActiveMessage())
 	{
 		TS_OpenLayoutList();
@@ -12185,8 +12187,9 @@ static void M_LayoutClearResponse(INT32 ch)
 	//M_StartMessage(M_GetText("Layout cleared.\n" PRESS_A_KEY_MESSAGE),NULL,MM_NOTHING);
 }
 
-static void M_ClearTouchControlLayout(void)
+static void M_ClearTouchControlLayout(INT32 choice)
 {
+	(void)choice;
 	if (!M_TouchPresetActiveMessage())
 	{
 		TS_OpenLayoutList();

--- a/src/st_stuff.c
+++ b/src/st_stuff.c
@@ -1514,7 +1514,7 @@ void ST_drawTouchGameInput(touchconfig_t *config, boolean drawgamecontrols, INT3
 {
 	const INT32 transflag = ((10-alphalevel)<<V_ALPHASHIFT);
 	const INT32 flags = (transflag | V_NOSCALESTART);
-	const INT32 accent = (stplyr->skincolor ? Color_Index[stplyr->skincolor-1][4] : 0);
+	const INT32 accent = (stplyr && stplyr->skincolor ? Color_Index[stplyr->skincolor-1][4] : 0);
 
 	touchconfig_t *tleft = &config[gc_strafeleft];
 	touchconfig_t *tright = &config[gc_straferight];
@@ -1540,10 +1540,10 @@ void ST_drawTouchGameInput(touchconfig_t *config, boolean drawgamecontrols, INT3
 			ST_drawTouchDPad(
 				touch_joystick_x, touch_joystick_y,
 				touch_joystick_w, touch_joystick_h,
-				tleft, (stplyr->cmd.sidemove < 0),
-				tright, (stplyr->cmd.sidemove > 0),
-				tup, (stplyr->cmd.forwardmove > 0),
-				tdown, (stplyr->cmd.forwardmove < 0),
+				tleft, (stplyr ? stplyr->cmd.sidemove < 0 : false),
+				tright, (stplyr ? stplyr->cmd.sidemove > 0 : false),
+				tup, (stplyr ? stplyr->cmd.forwardmove > 0 : false),
+				tdown, (stplyr ? stplyr->cmd.forwardmove < 0 : false),
 				true, flags, accent);
 		}
 		else // Draw the joystick


### PR DESCRIPTION
* Modified `M_...TouchControlLayout` functions to accept `choice` parameter, as-is standard for the other `IT_CALL` menu functions. My builds crashed before this fix.
* Fixed `stplyr == NULL` crash when entering the touch control layout screen in the title menu, before starting a level