### PR TITLE
Touch controls: Add ClearLayout fix to resolve missing buttons

### DIFF
--- a/src/ts_custom.c
+++ b/src/ts_custom.c
@@ -303,6 +303,10 @@ void TS_NewLayout(void)
 
 void TS_ClearLayout(void)
 {
+	INT32 i;
+	// reset hidden value so that all buttons are properly populated
+	for (i = 0; i < num_gamecontrols; i++)
+		usertouchcontrols[i].hidden = false;
 	// AAAANNDD this is where I would put my
 	// function that clears touchlayout_t...
 	// IF I HAD ONE!!!!


### PR DESCRIPTION
I think this merge is a hack, but it resolves an issue where `TS_ClearLayout` screws up on hidden buttons. 

I imagine you could code this properly.

## Before
![srb20000](https://user-images.githubusercontent.com/297483/85876057-25cd8680-b7a3-11ea-97e6-86626002cd47.gif)

## After
![srb20001](https://user-images.githubusercontent.com/297483/85876079-2ebe5800-b7a3-11ea-8e1d-7f82232ee2a2.gif)

(Ignore the positioning changes; those are from my fork)